### PR TITLE
feat: Silverstripe 6 compatibility (6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ A block that displays featured content - large image, title, description and lin
 
 ## Requirements
 
-- dnadesign/silverstripe-elemental: ^5
-- dynamic/silverstripe-elemental-baseobject: ^5
-- jonom/focuspoint: ^5
+- dnadesign/silverstripe-elemental: ^6
+- dynamic/silverstripe-elemental-baseobject: ^6
+- jonom/focuspoint: ^6
 
 ## Installation
 

--- a/_config.php
+++ b/_config.php
@@ -1,4 +1,3 @@
 <?php
 
-define('SILVERSTRIPE_ELEMENTAL-FEATURES_PATH', __DIR__);
-define('SILVERSTRIPE_ELEMENTAL-FEATURES_DIR', basename(__DIR__));
+// no-op

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,7 @@
         "elemental",
         "content",
         "blocks",
-        "feature",
-        "content"
+        "feature"
     ],
     "authors": [
         {
@@ -25,12 +24,13 @@
         }
     ],
     "require": {
-        "dnadesign/silverstripe-elemental": "^5",
-        "dynamic/silverstripe-elemental-baseobject": "^5",
-        "jonom/focuspoint": "^5.0"
+        "dnadesign/silverstripe-elemental": "^6",
+        "dynamic/silverstripe-elemental-baseobject": "^6",
+        "jonom/focuspoint": "^6.0",
+        "silverstripe/vendor-plugin": "^3"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^3"
+        "silverstripe/recipe-testing": "^4"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
@@ -47,6 +47,11 @@
             "silverstripe/vendor-plugin": true
         },
         "process-timeout": 600
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "6.x-dev"
+        }
     },
     "scripts": {
         "lint": "vendor/bin/phpcs src/ tests/",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/silverstripe/cms/tests/bootstrap.php"
+         colors="true">
     <testsuites>
         <testsuite name="Default">
             <directory>tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
+    <source>
+        <include>
             <directory suffix=".php">src/</directory>
-            <exclude>
-                <directory suffix=".php">tests/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
 </phpunit>


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Drop Silverstripe 5 support. This is a new major version (6.0) requiring Silverstripe 6 only.

## Changes

- **composer.json**: `elemental ^6`, `baseobject ^6`, `focuspoint ^6`, `vendor-plugin ^3`
- **require-dev**: `recipe-testing ^4`
- **branch-alias**: `6.x-dev`
- **phpunit.xml.dist**: Update to PHPUnit 11 format
- **_config.php**: Remove deprecated `define()` constants
- **README.md**: Update requirements to Silverstripe 6
- Removed duplicate `content` keyword

## Version History

| Version | Silverstripe |
|---------|-------------|
| 6.x     | ^6          |
| 5.x     | ^5          |
| 4.x     | ^4          |
